### PR TITLE
feat(build): Add Meson build system support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ To build the project, run the following command:
 cargo build
 ```
 
+### Building with Meson
+
+It is also possible to build the project using Meson. This is useful for packagers and developers who want to integrate the project with other Meson-based projects.
+
+First, ensure you have Meson installed. You can find installation instructions on the [Meson website](https://mesonbuild.com/Getting-meson.html).
+
+Once you have Meson installed, you can build the project using the following commands:
+
+```bash
+meson setup build --prefix=/usr
+meson compile -C build
+```
+
+To install the project, you can use the following command:
+
+```bash
+meson install -C build
+```
+
 ## Testing
 
 To run the test suite, use the following command:

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,9 @@
+oci_hook_conf = configuration_data()
+oci_hook_conf.set('oci-hooks-bindir', oci_hooks_bindir)
+configure_file(
+    input: 'oci-dev-binder-hook.json.in',
+    output: 'oci-dev-binder-hook.json',
+    configuration: oci_hook_conf,
+    install: true,
+    install_dir: oci_hooks_datadir
+)

--- a/data/oci-dev-binder-hook.json.in
+++ b/data/oci-dev-binder-hook.json.in
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "hook": {
+        "path": "@oci-hooks-bindir@/oci-dev-binder-hook"
+    },
+    "when": {
+        "annotations": {
+            "^org\\.containers\\.device\\..*$": "^.*$",
+            "^org\\.containers\\.logind\\.seat": "^.*$"
+        }
+    },
+    "stages": [
+        "precreate"
+    ]
+}

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,31 @@
+project('oci-dev-binder-hook', 'rust',
+        version: '0.1.0',
+        meson_version: '>= 0.60',
+        license: 'GPL-2.0-or-later'
+)
+
+cargo = find_program('cargo')
+udev = dependency('udev', required : true)
+
+prefix = get_option('prefix')
+bindir = prefix / get_option('bindir')
+libexec = prefix / get_option('libexecdir')
+datadir = prefix / get_option('datadir')
+oci_hooks_datadir = datadir / 'containers/oci/hooks.d'
+oci_hooks_bindir = libexec / 'oci/hooks.d'
+
+oci_dev_binder_hook_sources = files (
+    'Cargo.toml',
+    'src/lib.rs',
+    'src/main.rs',
+    'src/cli.rs',
+    'src/oci_spec.rs'
+)
+
+subdir('src')
+subdir('data')
+
+summary({
+  'Hook binary': oci_hooks_bindir / 'oci-dev-binder-hook',
+  'Hook configuration': oci_hooks_datadir / 'oci-dev-binder-hook.json',
+}, section: 'Configuration summary', bool_yn: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,10 @@
+option (
+  'profile',
+  type: 'combo',
+  choices: [
+    'default',
+    'development'
+  ],
+  value: 'default',
+  description: 'The build profile for oci-dev-binder-hook. One of "default" or "development".'
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,40 @@
+cargo_options = [ '--manifest-path', meson.project_source_root() / 'Cargo.toml' ]
+cargo_options += [ '--target-dir', meson.project_build_root() / 'src' ]
+
+if get_option('profile') == 'default'
+  cargo_options += [ '--release' ]
+  rust_target = 'release'
+  message('Building in release mode')
+else
+  rust_target = 'debug'
+  message('Building in debug mode')
+endif
+
+custom_target(
+  'oci-dev-binder-hook',
+  build_by_default: true,
+  input: oci_dev_binder_hook_sources,
+  output: meson.project_name(),
+  console: true,
+  install: true,
+  install_dir: oci_hooks_bindir,
+  command: [
+    cargo, 'build',
+    cargo_options,
+    '&&',
+    'cp', 'src' / rust_target / meson.project_name(), '@OUTPUT@',
+  ],
+  env: {
+    'CARGO_HOME': meson.project_build_root() / 'cargo-home',
+  }
+)
+
+test(
+  'cargo test',
+  cargo,
+  args: [ 'test', cargo_options ],
+  env: {
+    'CARGO_HOME': meson.project_build_root() / 'cargo-home',
+  },
+  verbose: true,
+)


### PR DESCRIPTION
This commit introduces Meson as a new build system, which is useful for packagers and developers who want to integrate the project with other Meson-based projects.

The following changes are included:
- Add `meson.build` files for the project, src and data
- Add `meson_options.txt` to support build profiles
- Add `oci-dev-binder-hook.json.in` for hook configuration
- Update `README.md` with Meson build instructions