### PR TITLE
Automate versioning and SRPM generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,10 @@
 project('oci-dev-binder-hook', 'rust',
-        version: '0.1.0',
-        meson_version: '>= 0.62',
+        version: run_command('tools/dist.sh', 'get-version', check: true).stdout().strip(),
+        meson_version: '>= 1.0.0',
         license: 'GPL-2.0-or-later'
 )
+
+meson.add_dist_script('tools/dist.sh', 'prepare-dist', meson.project_version())
 
 cargo = find_program('cargo')
 udev = dependency('udev', required : true)

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,10 @@ oci_dev_binder_hook_sources = files (
 subdir('src')
 subdir('data')
 
+if get_option('build_rpm_spec')
+    subdir('rpm')
+endif
+
 summary({
   'Hook binary': oci_hooks_bindir / 'oci-dev-binder-hook',
   'Hook configuration': oci_hooks_datadir / 'oci-dev-binder-hook.json',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option (
   value: 'default',
   description: 'The build profile for oci-dev-binder-hook. One of "default" or "development".'
 )
+option('build_rpm_spec', type: 'boolean', value: false, description: 'Build RPM spec file')

--- a/rpm/meson.build
+++ b/rpm/meson.build
@@ -1,0 +1,23 @@
+spec = configuration_data()
+
+project_version = meson.project_version()
+version_array = project_version.split('.')
+
+if 'dev' in meson.project_version()
+    version = '.'.join(version_array[0], version_array[1], version_array[2])
+    release = '1.' + version_array[3] + '%{?dist}'
+    dev_version = '.' + version_array[3]
+else
+    version = meson.project_version()
+    release = '%autorelease'
+    dev_version = ''
+endif
+
+spec.set('VERSION', version)
+spec.set('DEV_VERSION', dev_version)
+
+configure_file(
+    input: 'oci-dev-binder-hook.spec.in',
+    output: 'oci-dev-binder-hook.spec',
+    configuration: spec,
+)

--- a/rpm/oci-dev-binder-hook.spec.in
+++ b/rpm/oci-dev-binder-hook.spec.in
@@ -7,12 +7,12 @@
 %endif
 
 Name:           oci-dev-binder-hook
-Version:        0.1.0
-Release:        %autorelease
+Version:        @VERSION@
+Release:        1@DEV_VERSION@%{?dist}
 Summary:        OCI Device Binder Hook
 
 License:        GPL-2.0-or-later
-Source:         %{name}-%{version}.tar.xz
+Source:         %{name}-%{version}@DEV_VERSION@.tar.xz
 
 BuildRequires:  meson
 BuildRequires:  rust
@@ -29,11 +29,11 @@ OCI Device Binder Hook.
 %prep
 %if ! 0%{?bundled_rust_deps}
 # use packaged Rust dependencies
-%autosetup -p1 -n %{name}-%{version}
+%autosetup -p1 -n %{name}-%{version}@DEV_VERSION@
 %cargo_prep
 %else
 # use vendored Rust dependencies
-%autosetup -N -n %{name}-%{version} -a1
+%autosetup -N -n %{name}-%{version}@DEV_VERSION@ -a1
 %cargo_prep -v vendor
 %endif
 

--- a/tools/build-srpm.sh
+++ b/tools/build-srpm.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROJECT_NAME="oci-dev-binder-hook"
+PROJECT_DIR="$(dirname "$(readlink -f "$0")")/.."
+
+if ! command -v rpmbuild >/dev/null 2>&1; then
+    echo "rpmbuild not found. Please install rpm-build package." >&2
+    exit 1
+fi
+
+ALLOW_DIRTY=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dev)
+            export USE_GIT_VERSION=1
+            shift
+            ;;
+        --allow-dirty)
+            ALLOW_DIRTY=true
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+BUILD_DIR=$(mktemp -d)
+RPM_BUILD_ROOT="${BUILD_DIR}/rpmbuild"
+RPM_SOURCES="${RPM_BUILD_ROOT}/SOURCES"
+RPM_SPECS="${RPM_BUILD_ROOT}/SPECS"
+RPM_SRPMS="${RPM_BUILD_ROOT}/SRPMS"
+
+mkdir -p "${RPM_SOURCES}" "${RPM_SPECS}" "${RPM_SRPMS}"
+
+meson setup -Dbuild_rpm_spec=true $BUILD_DIR $PROJECT_DIR
+if [ "$ALLOW_DIRTY" = true ]; then
+    meson dist --allow-dirty --no-tests -C $BUILD_DIR
+else
+    meson dist --no-tests -C $BUILD_DIR
+fi
+
+cp $BUILD_DIR/meson-dist/*.tar.xz $RPM_SOURCES/
+cp $BUILD_DIR/rpm/$PROJECT_NAME.spec $RPM_SPECS/
+
+rpmbuild -bs --define "_topdir $RPM_BUILD_ROOT" $RPM_SPECS/$PROJECT_NAME.spec
+
+cp "${RPM_SRPMS}"/*.src.rpm ./
+
+trap 'rm -rf "${BUILD_DIR}"' EXIT

--- a/tools/dist.sh
+++ b/tools/dist.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+case "$1" in
+    get-version)
+        if ! [ -e Cargo.toml ]; then
+            echo "Cargo.toml not found" >&2
+            exit 1
+        fi
+
+        VERSION=$(grep '^version' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
+
+        if [[ -n "${USE_GIT_VERSION:-}" ]]; then
+            if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+                echo "Not a git repository" >&2
+                exit 1
+            fi
+            COMMIT_HASH=$(git rev-parse --short HEAD)
+            if [ -z "$(git tag -l)" ]; then
+                COMMITS_NUM_SINCE_LAST_TAG=$(git rev-list --count HEAD)
+            else
+                COMMITS_NUM_SINCE_LAST_TAG=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | wc -l)
+            fi
+            echo "${VERSION}.dev${COMMITS_NUM_SINCE_LAST_TAG}+${COMMIT_HASH}"
+        else
+            echo "${VERSION}"
+        fi
+        ;;
+    prepare-dist)
+        if [[ "$2" == *"dev"* ]]; then
+            $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
+        fi
+        ;;
+    *)
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
  This pull request introduces significant improvements to the build system, focusing on automated
  versioning and the generation of Source RPMs (SRPMs).

  Key changes include:

   * Automated Project Versioning:
       * The project version is no longer hardcoded and is now sourced dynamically from Cargo.toml.
       * A new tools/dist.sh script has been added to manage the version. It can append a development
         suffix (e.g., .dev5+g123456) based on Git history, which is useful for development builds.
       * The Meson build configuration has been updated to use this script to determine the project
         version.

   * SRPM Build Support:
       * A tools/build-srpm.sh script has been added to orchestrate the SRPM build process.
       * The RPM spec file has been converted to a .spec.in template to allow for dynamic version
         injection.
       * A new rpm/meson.build file configures the spec file, integrating it with the new automated
         versioning system.
